### PR TITLE
stop setting GIGBRANCH env variable

### DIFF
--- a/.travis_ci/prepare.sh
+++ b/.travis_ci/prepare.sh
@@ -5,8 +5,6 @@ ssh-keygen -t rsa -N "" -f ~/.ssh/main
 export SSHKEYNAME=main
 
 export GIGSAFE=1
-# export GIGBRANCH=$(git symbolic-ref --short HEAD)
-export GIGBRANCH=master
 export GIGDEVELOPERBRANCH=master
 
 curl https://raw.githubusercontent.com/Jumpscale/developer/$GIGDEVELOPERBRANCH/jsinit.sh?$RANDOM > /tmp/jsinit.sh; bash /tmp/jsinit.sh


### PR DESCRIPTION
Allow travis to set GIGBRANCH from the PR branch