### PR TITLE
Use prefab instead of j.sal in ays prefab module

### DIFF
--- a/modules/js9/PrefabAtYourService.py
+++ b/modules/js9/PrefabAtYourService.py
@@ -121,7 +121,7 @@ class PrefabAtYourService(base):
         Starts an AYS instance
         """
         # check if the install was called before
-        if not j.sal.fs.exists(j.sal.fs.joinPaths(self.base_dir, 'main.py')):
+        if not self.prefab.core.exists(j.sal.fs.joinPaths(self.base_dir, 'main.py')):
             self.logger.warning('AYS is not installed. Installing it...')
             self.install()
 


### PR DESCRIPTION
#### What this PR resolves:


#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #135
